### PR TITLE
Use a tag for basedeps dependency

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -11,4 +11,5 @@ galaxy_info:
   galaxy_tags: []
 
 dependencies:
-- role: openmicroscopy.basedeps
+- src: openmicroscopy.basedeps
+  version: 1.0.0


### PR DESCRIPTION
Do we want to go down the route of tagging all dependencies within a role?