### PR TITLE
Become  root before importing the RPM key

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,6 +2,7 @@
 # tasks file for roles/cli-utils
 
 - name: Import a key for epel
+  become: true
   ansible.builtin.rpm_key:
     state: present
     key:  https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-9


### PR DESCRIPTION
Encountered while testing the deployment of IDR on Rocky Linux 9